### PR TITLE
Fetch fail on denied

### DIFF
--- a/pkg/operation/fetch/fetch.go
+++ b/pkg/operation/fetch/fetch.go
@@ -45,13 +45,16 @@ func NewFetcher(kubeConfigPath string, conf *Config) (*Fetch, error) {
 // Fetch the generated certificate from the CSR
 func (f *Fetch) Fetch(csr *generate.Config) error {
 	glog.V(2).Infof("Start polling for certificate of csr/%s, every %s, timeout after %s", csr.Name, f.conf.PollingInterval.String(), f.conf.PollingTimeout.String())
+
 	tick := time.NewTicker(f.conf.PollingInterval)
 	defer tick.Stop()
+
 	timeout := time.NewTimer(f.conf.PollingTimeout)
 	defer tick.Stop()
 
 	ch := make(chan os.Signal)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(ch)
 
 	for {
 		select {

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -22,7 +22,7 @@ type Operation struct {
 	*Config
 }
 
-// NewOperation instanciate an Operation to potentially
+// NewOperation instantiate an Operation to potentially
 // - generate
 // - submit
 // - approve


### PR DESCRIPTION
### What does this PR do?

If the Kubernetes `csr` is denied, raise an error to save time.

### Additional Notes

Today when a `csr` is approved and then denied, the controller still issue the certificate.

Bugfix: Close the signal on SIGINT/TERM