### PR TITLE
Set annotations to track the activity of fetch

### DIFF
--- a/cmd/cli/cmd.go
+++ b/cmd/cli/cmd.go
@@ -259,18 +259,10 @@ func newFetchClient() (*fetch.Fetch, error) {
 		crtPath = path.Join(wd, crtPath)
 	}
 
-	fetchInterval := viperConfig.GetDuration("fetch-interval")
-	timeoutInterval := viperConfig.GetDuration("fetch-timeout")
-	if !viperConfig.GetBool("approve") {
-		fetchInterval = defaultFetchInterval * 10
-		timeoutInterval = defaultTimeoutInterval * 10
-		glog.V(2).Infof("csr externally approved, setting the polling interval to %s and the timeout to %s", fetchInterval.String(), timeoutInterval.String())
-	}
-
 	conf := &fetch.Config{
 		Override:              viperConfig.GetBool("override"),
-		PollingInterval:       fetchInterval,
-		PollingTimeout:        timeoutInterval,
+		PollingInterval:       viperConfig.GetDuration("fetch-interval"),
+		PollingTimeout:        viperConfig.GetDuration("fetch-timeout"),
 		CertificatePermission: os.FileMode(viperConfig.GetInt("certificate-perm")),
 		CertificateABSPath:    crtPath,
 	}

--- a/pkg/operation/fetch/fetch.go
+++ b/pkg/operation/fetch/fetch.go
@@ -4,16 +4,26 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/golang/glog"
 	certificates "k8s.io/api/certificates/v1beta1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/JulienBalestra/kube-csr/pkg/operation/generate"
 	"github.com/JulienBalestra/kube-csr/pkg/utils/kubeclient"
 	"github.com/JulienBalestra/kube-csr/pkg/utils/pemio"
+)
+
+const (
+	// KubeCsrFetchedAnnotationDate is an annotation used to store the timestamp when the certificated has been fetched
+	// This annotation is overridden by the latest fetch
+	KubeCsrFetchedAnnotationDate = "alpha.kube-csr/lastFetched"
+
+	// KubeCsrFetchedAnnotationNb is an annotation used to count the number of fetches of the certificate
+	KubeCsrFetchedAnnotationNb = "alpha.kube-csr/countFetched"
 )
 
 // Config of the Fetch
@@ -43,6 +53,34 @@ func NewFetcher(kubeConfigPath string, conf *Config) (*Fetch, error) {
 	}, nil
 }
 
+func (f *Fetch) updateAnnotations(r *certificates.CertificateSigningRequest) error {
+	now := time.Now().UTC().Format("2006-01-02T15:04:05Z")
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{
+			KubeCsrFetchedAnnotationDate: now,
+			KubeCsrFetchedAnnotationNb:   "1",
+		}
+	} else {
+		r.Annotations[KubeCsrFetchedAnnotationDate] = now
+		nbString := r.Annotations[KubeCsrFetchedAnnotationNb]
+		// if the annotation doesn't exists, nbString is set to "" which is transformed to 0 by Atoi
+		nb, err := strconv.Atoi(nbString)
+		if err != nil {
+			glog.Warningf("Cannot parse the annotation %s: %q: %v", KubeCsrFetchedAnnotationNb, nbString, err)
+		}
+		r.Annotations[KubeCsrFetchedAnnotationNb] = strconv.Itoa(nb + 1)
+		glog.V(2).Infof("csr/%s was already fetched before, incr %q annotation to %s", r.Name, KubeCsrFetchedAnnotationNb, r.Annotations[KubeCsrFetchedAnnotationNb])
+	}
+
+	glog.V(4).Infof("Annotate csr/%s: %s: %s", r.Name, KubeCsrFetchedAnnotationDate, now)
+	r, err := f.kubeClient.GetCertificateClient().CertificateSigningRequests().Update(r)
+	if err != nil {
+		glog.Errorf("Cannot update annotation of csr/%s: %v", r.Name, err)
+		return err
+	}
+	return nil
+}
+
 // Fetch the generated certificate from the CSR
 func (f *Fetch) Fetch(csr *generate.Config) error {
 	glog.V(2).Infof("Start polling for certificate of csr/%s, every %s, timeout after %s", csr.Name, f.conf.PollingInterval.String(), f.conf.PollingTimeout.String())
@@ -65,12 +103,16 @@ func (f *Fetch) Fetch(csr *generate.Config) error {
 
 		case <-tick.C:
 			// TODO as we are waiting the ticker, if the ticker is set to 10s, we start polling after 10s
-			r, err := f.kubeClient.GetCertificateClient().CertificateSigningRequests().Get(csr.Name, v1.GetOptions{})
+			r, err := f.kubeClient.GetCertificateClient().CertificateSigningRequests().Get(csr.Name, metav1.GetOptions{})
 			if err != nil {
 				glog.Errorf("Unexpected error during certificate fetching of csr/%s: %s", csr.Name, err)
 				return err
 			}
 			if r.Status.Certificate != nil {
+				err := f.updateAnnotations(r)
+				if err != nil {
+					return err
+				}
 				glog.V(3).Infof("csr/%s:\n%s", csr.Name, string(r.Status.Certificate))
 				glog.V(2).Infof("Certificate successfully fetched, writing %d chars to %s", len(r.Status.Certificate), f.conf.CertificateABSPath)
 				return pemio.WriteFile(r.Status.Certificate, f.conf.CertificateABSPath, f.conf.CertificatePermission, f.conf.Override)


### PR DESCRIPTION
### What does this PR do?

When fetching the certificate, `kube-csr` sets two annotations:
* `alpha.kube-csr/lastFetched`
* `alpha.kube-csr/countFetched`
```
./kube-csr my-app -gasf --subject-alternative-names 192.168.1.1,etcd-0.default.svc.cluster.local --override --kubeconfig-path ~/.kube/config --fetch-interval 2s
I0609 16:33:23.596627    6052 kubeclient.go:45] Building flags kube-config with /home/jb/.kube/config
I0609 16:33:23.598109    6052 kubeclient.go:45] Building flags kube-config with /home/jb/.kube/config
I0609 16:33:23.598614    6052 kubeclient.go:45] Building flags kube-config with /home/jb/.kube/config
I0609 16:33:23.700556    6052 generate.go:59] Added IP address 192.168.1.1
I0609 16:33:23.700576    6052 generate.go:64] Added DNS name etcd-0.default.svc.cluster.local
I0609 16:33:23.700581    6052 generate.go:73] CSR with 1 DNS names and 1 IP addresses
I0609 16:33:23.700586    6052 generate.go:94] Generating CSR with CN=my-app
I0609 16:33:23.703141    6052 write.go:43] Override existing: /home/jb/go/src/github.com/JulienBalestra/kube-csr/kube-csr.private_key
I0609 16:33:23.703208    6052 write.go:57] Wrote RSA PRIVATE KEY to /home/jb/go/src/github.com/JulienBalestra/kube-csr/kube-csr.private_key
I0609 16:33:23.703282    6052 write.go:43] Override existing: /home/jb/go/src/github.com/JulienBalestra/kube-csr/kube-csr.csr
I0609 16:33:23.703311    6052 write.go:57] Wrote CERTIFICATE REQUEST to /home/jb/go/src/github.com/JulienBalestra/kube-csr/kube-csr.csr
W0609 16:33:23.713707    6052 submit.go:80] csr/my-app-haf already exists, deleting ...
I0609 16:33:23.715850    6052 submit.go:86] Successfully deleted csr/my-app-haf, re-creating ...
I0609 16:33:23.718139    6052 submit.go:93] Successfully created csr/my-app-haf 10750b2c-6bf2-11e8-bb7f-5404a66983a9
I0609 16:33:23.718155    6052 approve.go:38] Approving csr/my-app-haf ...
I0609 16:33:23.720323    6052 approve.go:49] csr/my-app-haf is approved
I0609 16:33:23.720346    6052 fetch.go:84] Start polling for certificate of csr/my-app-haf, every 2s, timeout after 10s
I0609 16:33:25.726553    6052 fetch.go:115] Certificate successfully fetched, writing 1233 chars to /home/jb/go/src/github.com/JulienBalestra/kube-csr/kube-csr.certificate
I0609 16:33:25.726606    6052 write.go:20] Override existing: /home/jb/go/src/github.com/JulienBalestra/kube-csr/kube-csr.certificate
```

```
./kube-csr my-app -f --subject-alternative-names 192.168.1.1,etcd-0.default.svc.cluster.local --override --kubeconfig-path ~/.kube/config --fetch-interval 2s
I0609 16:33:37.418118    6076 kubeclient.go:45] Building flags kube-config with /home/jb/.kube/config
I0609 16:33:37.419580    6076 fetch.go:84] Start polling for certificate of csr/my-app-haf, every 2s, timeout after 10s
I0609 16:33:39.430060    6076 fetch.go:70] csr/my-app-haf was already fetched before, incr "alpha.kube-csr/countFetched" annotation to 2
I0609 16:33:39.440009    6076 fetch.go:115] Certificate successfully fetched, writing 1233 chars to /home/jb/go/src/github.com/JulienBalestra/kube-csr/kube-csr.certificate
I0609 16:33:39.440042    6076 write.go:20] Override existing: /home/jb/go/src/github.com/JulienBalestra/kube-csr/kube-csr.certificate
```
```
kubectl get csr my-app-haf -o yaml
apiVersion: certificates.k8s.io/v1beta1
kind: CertificateSigningRequest
metadata:
  annotations:
    alpha.kube-csr/countFetched: "2"
    alpha.kube-csr/lastFetched: 2018-06-09T14:33:39Z
  creationTimestamp: 2018-06-09T14:33:23Z
[...]
```

### Motivation

This feature will be useful to provide any `purge` behavior.

### Additional Notes

I removed the broken logic around the fetch without any `approve` flag.