### PR TITLE
Be able to skip the fetch annotation updates

### DIFF
--- a/cmd/cli/cmd.go
+++ b/cmd/cli/cmd.go
@@ -173,6 +173,9 @@ func NewCommand() (*cobra.Command, *int) {
 	rootCommand.PersistentFlags().Duration("fetch-timeout", viperConfig.GetDuration("fetch-timeout"), "Polling timeout for certificate fetching")
 	viperConfig.BindPFlag("fetch-timeout", rootCommand.PersistentFlags().Lookup("fetch-timeout"))
 
+	rootCommand.PersistentFlags().Bool("skip-fetch-annotate", viperConfig.GetBool("skip-fetch-annotate"), "Skip the update of annotations when succesfully fetched the certificate")
+	viperConfig.BindPFlag("skip-fetch-annotate", rootCommand.PersistentFlags().Lookup("skip-fetch-annotate"))
+
 	return rootCommand, &exitCode
 }
 
@@ -265,6 +268,7 @@ func newFetchClient() (*fetch.Fetch, error) {
 		PollingTimeout:        viperConfig.GetDuration("fetch-timeout"),
 		CertificatePermission: os.FileMode(viperConfig.GetInt("certificate-perm")),
 		CertificateABSPath:    crtPath,
+		Annotate:              !viperConfig.GetBool("skip-fetch-annotate"),
 	}
 	f, err := fetch.NewFetcher(viperConfig.GetString("kubeconfig-path"), conf)
 	if err != nil {

--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -40,4 +40,5 @@ func init() {
 	viperConfig.SetDefault("certificate-perm", 0600)
 	viperConfig.SetDefault("fetch-interval", defaultFetchInterval)
 	viperConfig.SetDefault("fetch-timeout", defaultTimeoutInterval)
+	viperConfig.SetDefault("skip-fetch-annotate", false)
 }

--- a/docs/kube-csr.md
+++ b/docs/kube-csr.md
@@ -53,6 +53,7 @@ kube-csr my-app -gsaf --override --kubeconfig-path ~/.kube/config
       --override                            Override any existing file pem and k8s csr resource
       --private-key-file string             Private key file target (default "kube-csr.private_key")
       --rsa-bits string                     RSA bits for the private key (default "2048")
+      --skip-fetch-annotate                 Skip the update of annotations when succesfully fetched the certificate
       --subject-alternative-names strings   Subject Alternative Names (SANs) comma separated
   -s, --submit                              Submit the CSR
   -v, --verbose int                         verbose level (default 2)

--- a/pkg/operation/fetch/fetch.go
+++ b/pkg/operation/fetch/fetch.go
@@ -33,6 +33,7 @@ type Config struct {
 	PollingTimeout        time.Duration
 	CertificateABSPath    string
 	CertificatePermission os.FileMode
+	Annotate              bool
 }
 
 // Fetch state
@@ -54,6 +55,10 @@ func NewFetcher(kubeConfigPath string, conf *Config) (*Fetch, error) {
 }
 
 func (f *Fetch) updateAnnotations(r *certificates.CertificateSigningRequest) error {
+	if !f.conf.Annotate {
+		glog.V(2).Infof("Skipping the annotations update")
+		return nil
+	}
 	now := time.Now().UTC().Format("2006-01-02T15:04:05Z")
 	if r.Annotations == nil {
 		r.Annotations = map[string]string{


### PR DESCRIPTION
### What does this PR do?

Provide a way to skip the annotation-update of the fetch package.

### Motivation

On large cluster, we may want to skip this feature because it does an update over the apiserver.