### PR TITLE
tickers: must be non zero

### DIFF
--- a/pkg/operation/fetch/fetch.go
+++ b/pkg/operation/fetch/fetch.go
@@ -50,6 +50,16 @@ type Fetch struct {
 
 // NewFetcher creates a new Fetch
 func NewFetcher(kubeConfigPath string, conf *Config) (*Fetch, error) {
+	if conf.PollingInterval == 0 {
+		err := fmt.Errorf("invalid value for PollingInterval: %s", conf.PollingInterval.String())
+		glog.Errorf("Cannot use the provided config: %v", err)
+		return nil, err
+	}
+	if conf.PollingTimeout == 0 {
+		err := fmt.Errorf("invalid value for PollingTimeout: %s", conf.PollingTimeout.String())
+		glog.Errorf("Cannot use the provided config: %v", err)
+		return nil, err
+	}
 	k, err := kubeclient.NewKubeClient(kubeConfigPath)
 	if err != nil {
 		return nil, err

--- a/pkg/operation/purge/purge.go
+++ b/pkg/operation/purge/purge.go
@@ -1,6 +1,7 @@
 package purge
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -88,6 +89,11 @@ func RegisterPrometheusMetrics(p *Purge) error {
 
 // NewPurge creates a new Fetch
 func NewPurge(kubeConfigPath string, conf *Config) (*Purge, error) {
+	if conf.PollingPeriod == 0 {
+		err := fmt.Errorf("invalid value for PollingPeriod: %s", conf.PollingPeriod.String())
+		glog.Errorf("Cannot use the provided config: %v", err)
+		return nil, err
+	}
 	k, err := kubeclient.NewKubeClient(kubeConfigPath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What does this PR do?

When using `0s` as duration for any tickers, it panics.
```
./kube-csr gc --denied --daemon --polling-period=0s --kubeconfig-path ~/.kube/config 
panic: non-positive interval for NewTicker
[...]
```

