### PR TITLE
Introduce pupernetes as e2e testing engine.

### DIFF
--- a/.ci/e2e.sh
+++ b/.ci/e2e.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+cd $(dirname $0)/..
+
+./kube-csr issue e2e --generate --submit --approve --fetch --kubeconfig-path $HOME/.kube/config
+./kube-csr issue e2e --generate --submit --approve --fetch --override --kubeconfig-path $HOME/.kube/config
+kubectl get secret -o json | jq -re '.items[].data["ca.crt"]' | base64 -d > ca.crt
+openssl verify -CAfile ca.crt kube-csr.certificate
+
+kubectl apply -f examples/etcd.yaml
+timeout 600 ./.ci/etcd.sh
+
+./kube-csr garbage-collect --fetched --grace-period=1h --kubeconfig-path $HOME/.kube/config
+./kube-csr garbage-collect --denied --grace-period=0s --kubeconfig-path $HOME/.kube/config
+./kube-csr garbage-collect --fetched --grace-period=0s --kubeconfig-path $HOME/.kube/config
+./kube-csr garbage-collect --fetched --denied --grace-period=0s --kubeconfig-path $HOME/.kube/config

--- a/.ci/etcd.sh
+++ b/.ci/etcd.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+while true
+do
+    echo "---"
+    kubectl get statefulset,job,po,csr --all-namespaces -o wide
+    kubectl get po -n default -o json -l app=etcdctl | jq -re '.items[] | select(.status.phase=="Succeeded")' && exit 0
+    sleep 10
+done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,16 +94,19 @@ jobs:
           name: cli
           command: ./kube-csr issue e2e --generate --submit --approve --fetch --kubeconfig-path $HOME/.kube/config
       - run:
+          name: cli-override
+          command: ./kube-csr issue e2e --generate --submit --approve --fetch --override --kubeconfig-path $HOME/.kube/config
+      - run:
           name: get-ca
           command: kubectl get secret -o json | jq -re '.items[].data["ca.crt"]' | base64 -d > ca.crt
       - run:
           name: openssl-verify
           command: openssl verify -CAfile ca.crt kube-csr.certificate
       - run:
-          name: kubectl
+          name: kubectl-etcd
           command: kubectl apply -f examples/etcd.yaml
       - run:
-          name: etcd
+          name: check-etcd
           command: timeout 600 ./.ci/etcd.sh
       - run:
           name: grace-delete-csr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ templates:
     working_directory: /home/circleci/.go_workspace/src/github.com/JulienBalestra/kube-csr
     environment:
       DEBIAN_FRONTEND: "noninteractive"
+      CFLAGS: ""
+      CGO_ENABLED: "1"
 
 jobs:
   make:
@@ -69,24 +71,49 @@ jobs:
     steps:
       - checkout
       - run:
+          name: docker-image
+          # Override the latest tag by the current branch, in the store.
+          # TODO: use the image built by quay for this branch
+          command: sudo docker build -t quay.io/julienbalestra/kube-csr:latest .
+      - run:
           name: kubeconfig
-          command: mkdir -pv $HOME/.kube && touch $HOME/.kube/config
+          command: mkdir -pv $HOME/.kube && touch $HOME/.kube/config && sudo ln -sv /home/circleci/.kube /.kube
       - run:
           name: download
           command: sudo curl -Lf https://github.com/DataDog/pupernetes/releases/download/v0.5.0/pupernetes -o /usr/local/bin/pupernetes && sudo chmod +x /usr/local/bin/pupernetes
       - run:
           name: apt
-          command: sudo apt-get update -qq && sudo apt-get install -yqq systemd
+          command: sudo apt-get update -qq && sudo apt-get install -yqq systemd openssl
       - run:
           name: run
           command: sudo /usr/local/bin/pupernetes daemon run sandbox/ --job-type systemd --kubectl-link /usr/local/bin/kubectl
+      - run:
+          name: make
+          command: make
+      - run:
+          name: cli
+          command: ./kube-csr issue e2e --generate --submit --approve --fetch --kubeconfig-path $HOME/.kube/config
+      - run:
+          name: get-ca
+          command: kubectl get secret -o json | jq -re '.items[].data["ca.crt"]' | base64 -d > ca.crt
+      - run:
+          name: openssl-verify
+          command: openssl verify -CAfile ca.crt kube-csr.certificate
       - run:
           name: kubectl
           command: kubectl apply -f examples/etcd.yaml
       - run:
           name: etcd
-          command: ./.ci/etcd.sh
-
+          command: timeout 600 ./.ci/etcd.sh
+      - run:
+          name: grace-delete-csr
+          command: ./kube-csr garbage-collect --fetched --grace-period=1h --kubeconfig-path $HOME/.kube/config
+      - run:
+          name: no-delete-csr
+          command: ./kube-csr garbage-collect --denied --grace-period=0s --kubeconfig-path $HOME/.kube/config
+      - run:
+          name: delete-csr
+          command: ./kube-csr garbage-collect --fetched --grace-period=0s --kubeconfig-path $HOME/.kube/config
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,12 @@ templates:
       - image: golang:1.10
     working_directory: /go/src/github.com/JulienBalestra/kube-csr
 
+  machine_job_template: &machine_job_template
+    machine: true
+    working_directory: /home/circleci/.go_workspace/src/github.com/JulienBalestra/kube-csr
+    environment:
+      DEBIAN_FRONTEND: "noninteractive"
+
 jobs:
   make:
     <<: *job_template
@@ -58,6 +64,29 @@ jobs:
           name: verify ineffassign golint misspell
           command: make -j verify-misc
 
+  pupernetes:
+    <<: *machine_job_template
+    steps:
+      - checkout
+      - run:
+          name: kubeconfig
+          command: mkdir -pv $HOME/.kube && touch $HOME/.kube/config
+      - run:
+          name: download
+          command: sudo curl -Lf https://github.com/DataDog/pupernetes/releases/download/v0.5.0/pupernetes -o /usr/local/bin/pupernetes && sudo chmod +x /usr/local/bin/pupernetes
+      - run:
+          name: apt
+          command: sudo apt-get update -qq && sudo apt-get install -yqq systemd
+      - run:
+          name: run
+          command: sudo /usr/local/bin/pupernetes daemon run sandbox/ --job-type systemd --kubectl-link /usr/local/bin/kubectl
+      - run:
+          name: kubectl
+          command: kubectl apply -f examples/etcd.yaml
+      - run:
+          name: etcd
+          command: ./.ci/etcd.sh
+
 
 workflows:
   version: 2
@@ -76,3 +105,6 @@ workflows:
       - license
       - misc
 
+  e2e:
+    jobs:
+      - pupernetes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,35 +91,8 @@ jobs:
           name: make
           command: make
       - run:
-          name: cli
-          command: ./kube-csr issue e2e --generate --submit --approve --fetch --kubeconfig-path $HOME/.kube/config
-      - run:
-          name: cli-override
-          command: ./kube-csr issue e2e --generate --submit --approve --fetch --override --kubeconfig-path $HOME/.kube/config
-      - run:
-          name: get-ca
-          command: kubectl get secret -o json | jq -re '.items[].data["ca.crt"]' | base64 -d > ca.crt
-      - run:
-          name: openssl-verify
-          command: openssl verify -CAfile ca.crt kube-csr.certificate
-      - run:
-          name: kubectl-etcd
-          command: kubectl apply -f examples/etcd.yaml
-      - run:
-          name: check-etcd
-          command: timeout 600 ./.ci/etcd.sh
-      - run:
-          name: grace-delete-csr
-          command: ./kube-csr garbage-collect --fetched --grace-period=1h --kubeconfig-path $HOME/.kube/config
-      - run:
-          name: no-delete-csr
-          command: ./kube-csr garbage-collect --denied --grace-period=0s --kubeconfig-path $HOME/.kube/config
-      - run:
-          name: delete-csr
-          command: ./kube-csr garbage-collect --fetched --grace-period=0s --kubeconfig-path $HOME/.kube/config
-      - run:
-          name: empty-delete-csr
-          command: ./kube-csr garbage-collect --fetched --denied --grace-period=0s --kubeconfig-path $HOME/.kube/config
+          name: e2e
+          command: ./.ci/e2e.sh
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,9 @@ jobs:
       - run:
           name: delete-csr
           command: ./kube-csr garbage-collect --fetched --grace-period=0s --kubeconfig-path $HOME/.kube/config
+      - run:
+          name: empty-delete-csr
+          command: ./kube-csr garbage-collect --fetched --denied --grace-period=0s --kubeconfig-path $HOME/.kube/config
 
 workflows:
   version: 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: go
+
+go: "1.10"
+
+os:
+  - linux
+
+sudo: required
+dist: trusty
+
+env:
+  matrix:
+    - HYPERKUBE_VERSION=1.10.1
+
+before_install:
+  - sudo apt-get update -qq
+
+  # TODO: revamp with p8s --kubeconfig-path
+  - mkdir -pv $HOME/.kube && touch $HOME/.kube/config && sudo ln -sv $HOME/.kube /.kube
+
+install:
+  # Override the latest tag by the current branch, in the store.
+  # TODO: use the image built by quay for this branch
+  - sudo docker build -t quay.io/julienbalestra/kube-csr:latest .
+
+  - sudo apt-get install -yqq systemd openssl
+  - sudo curl -Lf https://storage.googleapis.com/kubernetes-release/release/v$HYPERKUBE_VERSION/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl
+  - sudo chmod +x /usr/local/bin/kubectl
+  - sudo curl -Lf https://github.com/DataDog/pupernetes/releases/download/v0.5.0/pupernetes -o /usr/local/bin/pupernetes
+  - sudo chmod +x /usr/local/bin/pupernetes
+
+script:
+  - sudo /usr/local/bin/pupernetes daemon run sandbox/ --job-type systemd --hyperkube-version $HYPERKUBE_VERSION
+  - make
+  - ./.ci/e2e.sh

--- a/examples/etcd.yaml
+++ b/examples/etcd.yaml
@@ -41,6 +41,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: etcd
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -146,10 +147,14 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: etcdctl
+  namespace: default
 spec:
   backoffLimit: 5
   activeDeadlineSeconds: 60
   template:
+    metadata:
+      labels:
+        app: etcdctl
     spec:
       containers:
       - name: etcdctl


### PR DESCRIPTION
### What does this PR do?

This PR introduce pupernetes as e2e testing engine.

### Motivation

End to end coverage.
Quickly provides Kubernetes API.

### Additional Notes

I needed to use [pupernetes](https://github.com/DataDog/pupernetes) as abspath because of the following issue https://github.com/DataDog/pupernetes/issues/72.