### PR TITLE
Add an expired purge capability

### DIFF
--- a/.ci/e2e.sh
+++ b/.ci/e2e.sh
@@ -14,5 +14,6 @@ timeout 600 ./.ci/etcd.sh
 
 ./kube-csr garbage-collect --fetched --grace-period=1h --kubeconfig-path $HOME/.kube/config
 ./kube-csr garbage-collect --denied --grace-period=0s --kubeconfig-path $HOME/.kube/config
+./kube-csr garbage-collect --expired --grace-period=0s --kubeconfig-path $HOME/.kube/config
 ./kube-csr garbage-collect --fetched --grace-period=0s --kubeconfig-path $HOME/.kube/config
-./kube-csr garbage-collect --fetched --denied --grace-period=0s --kubeconfig-path $HOME/.kube/config
+./kube-csr garbage-collect --fetched --denied --expired --grace-period=0s --kubeconfig-path $HOME/.kube/config

--- a/docs/kube-csr_garbage-collect.md
+++ b/docs/kube-csr_garbage-collect.md
@@ -34,6 +34,7 @@ kube-csr gc --fetched --daemon polling-period=10m --grace-period=1h
       --daemon                        continually gc Kubernetes csr, paired with --polling-period
       --denied                        delete any denied Kubernetes csr
       --disable-prometheus-exporter   disable /metrics, paired with --daemon
+      --expired                       delete any Kubernetes csr with an expired certificate
       --fetched                       delete any already fetched Kubernetes csr, the state is tracked with kube-annotations "alpha.kube-csr/"
       --grace-period duration         duration to wait before deleting Kubernetes csr objects (default 48h0m0s)
   -h, --help                          help for garbage-collect

--- a/pkg/operation/purge/purge.go
+++ b/pkg/operation/purge/purge.go
@@ -113,21 +113,14 @@ func NewPurge(kubeConfigPath string, conf *Config) (*Purge, error) {
 	return p, nil
 }
 
+// durationFormat is a convenient fmt function to display the duration
 func durationFormat(duration time.Duration) string {
 	if duration.Seconds() < 0 {
 		duration = -duration
 	}
-	var months, days int
+	var days int
 	for {
-		if duration.Hours() > (31 * 24) {
-			months++
-			duration = duration - (31 * 24 * time.Hour)
-		}
-		if days > 31 {
-			months++
-			days = days - 31
-		}
-		if duration.Hours() > 24 {
+		if duration.Hours() >= 24 {
 			days++
 			duration = duration - time.Hour*24
 			continue
@@ -138,10 +131,7 @@ func durationFormat(duration time.Duration) string {
 	if days == 0 {
 		return duration.String()
 	}
-	if months == 0 {
-		return fmt.Sprintf("%d days %s", days, duration.String())
-	}
-	return fmt.Sprintf("%d months %d days and %s", months, days, duration.String())
+	return fmt.Sprintf("%d days and %s", days, duration.String())
 }
 
 // IsCertificateExpired returns if the certificate of the csr is expired according the "Not After" field

--- a/pkg/operation/purge/purge.go
+++ b/pkg/operation/purge/purge.go
@@ -1,6 +1,8 @@
 package purge
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"os"
@@ -109,6 +111,67 @@ func NewPurge(kubeConfigPath string, conf *Config) (*Purge, error) {
 		return nil, err
 	}
 	return p, nil
+}
+
+func durationFormat(duration time.Duration) string {
+	if duration.Seconds() < 0 {
+		duration = -duration
+	}
+	var months, days int
+	for {
+		if duration.Hours() > (31 * 24) {
+			months++
+			duration = duration - (31 * 24 * time.Hour)
+		}
+		if days > 31 {
+			months++
+			days = days - 31
+		}
+		if duration.Hours() > 24 {
+			days++
+			duration = duration - time.Hour*24
+			continue
+		}
+		break
+	}
+	duration = duration.Round(time.Second)
+	if days == 0 {
+		return duration.String()
+	}
+	if months == 0 {
+		return fmt.Sprintf("%d days %s", days, duration.String())
+	}
+	return fmt.Sprintf("%d months %d days and %s", months, days, duration.String())
+}
+
+// IsCertificateExpired returns if the certificate of the csr is expired according the "Not After" field
+func IsCertificateExpired(csr *certificates.CertificateSigningRequest, gracePeriod time.Duration) bool {
+	if csr.Status.Certificate == nil {
+		glog.V(2).Infof("csr/%s uid: %s does not have any certificate", csr.Name, csr.UID)
+		return false
+	}
+	block, rest := pem.Decode(csr.Status.Certificate)
+	if len(rest) > 0 {
+		glog.Errorf("Unexpected result after certificate decode of csr/%s uid %s %s", csr.Name, csr.UID, string(rest))
+		return false
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		glog.Errorf("Cannot parse certificate of csr/%s uid %s: %v", csr.Name, csr.UID, err)
+		return false
+	}
+	now := time.Now()
+	if now.Before(cert.NotAfter) {
+		glog.V(2).Infof("csr/%s uid %s not expired, NotAfter: %s, still %s", csr.Name, csr.UID, cert.NotAfter.Format(fetch.KubeCsrFetchedAnnotationDateFormat), durationFormat(cert.NotAfter.Sub(now)))
+		return false
+	}
+	glog.V(2).Infof("csr/%s uid: %s expired since %s", csr.Name, csr.UID, durationFormat(time.Since(cert.NotAfter)))
+	gracePeriodLimit := now.Add(-gracePeriod)
+	if gracePeriodLimit.Before(cert.NotAfter) {
+		glog.V(2).Infof("csr/%s uid %s is expired but still in grace period of %s", csr.Name, csr.UID, durationFormat(cert.NotAfter.Sub(gracePeriodLimit)))
+		return false
+	}
+	return true
 }
 
 // IsConditionDenied returns if the first condition of the csr is a type Denied

--- a/pkg/operation/purge/purge_test.go
+++ b/pkg/operation/purge/purge_test.go
@@ -1,0 +1,109 @@
+package purge
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	certificates "k8s.io/api/certificates/v1beta1"
+)
+
+func TestDurationFormat(t *testing.T) {
+	for _, tc := range []struct {
+		d      time.Duration
+		output string
+	}{
+		{
+			d:      5 * time.Hour,
+			output: "5h0m0s",
+		},
+		{
+			d:      25 * time.Hour,
+			output: "1 days and 1h0m0s",
+		},
+		{
+			d:      49 * time.Hour,
+			output: "2 days and 1h0m0s",
+		},
+		{
+			d:      31 * 24 * time.Hour,
+			output: "31 days and 0s",
+		},
+		{
+			d:      365 * 24 * time.Hour,
+			output: "365 days and 0s",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, tc.output, durationFormat(tc.d))
+		})
+	}
+}
+
+func generateCertOrDie(notAfter time.Time) []byte {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		panic(err)
+	}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Hour * 24 * 31),
+		NotAfter:     notAfter,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, privateKey.Public(), privateKey)
+	if err != nil {
+		panic(err)
+	}
+	out := &bytes.Buffer{}
+	err = pem.Encode(out, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	if err != nil {
+		panic(err)
+	}
+	return out.Bytes()
+}
+
+func TestIsCertificateExpired(t *testing.T) {
+	for _, tc := range []struct {
+		csr         *certificates.CertificateSigningRequest
+		gracePeriod time.Duration
+		expired     bool
+	}{
+		{
+			csr: &certificates.CertificateSigningRequest{
+				Status: certificates.CertificateSigningRequestStatus{
+					Certificate: generateCertOrDie(time.Now().Add(-time.Hour)),
+				},
+			},
+			gracePeriod: time.Minute * 45,
+			expired:     true,
+		},
+		{
+			csr: &certificates.CertificateSigningRequest{
+				Status: certificates.CertificateSigningRequestStatus{
+					Certificate: generateCertOrDie(time.Now().Add(-time.Hour)),
+				},
+			},
+			gracePeriod: time.Minute * 61,
+			expired:     false,
+		},
+		{
+			csr: &certificates.CertificateSigningRequest{
+				Status: certificates.CertificateSigningRequestStatus{
+					Certificate: generateCertOrDie(time.Now().Add(time.Hour)),
+				},
+			},
+			gracePeriod: time.Minute * 1,
+			expired:     false,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, tc.expired, IsCertificateExpired(tc.csr, tc.gracePeriod))
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Following #36 

Purge any Kubernetes csr object when the `status.certificate` is expired.

### Additional Notes

It seems all certificates are valid one year regardless the expiry of the certificate authority itself.