### PR TITLE
Add the metrics-server as example

### DIFF
--- a/.ci/e2e.sh
+++ b/.ci/e2e.sh
@@ -4,13 +4,19 @@ set -exuo pipefail
 
 cd $(dirname $0)/..
 
+REQUEST_HEADER_CLIENT_CA=$(kubectl get cm -n kube-system extension-apiserver-authentication -o json | jq '.data["requestheader-client-ca-file"]' -re | base64 | tr -d '\n')
+sed s/REQUEST_HEADER_CLIENT_CA/"${REQUEST_HEADER_CLIENT_CA}"/g examples/metrics-server.yaml > ./.ci/metrics-server.yaml
+kubectl apply -f ./.ci/metrics-server.yaml
+kubectl apply -f examples/etcd.yaml
+
+go run examples/issue.go
+
 ./kube-csr issue e2e --generate --submit --approve --fetch --kubeconfig-path $HOME/.kube/config
 ./kube-csr issue e2e --query-svc=default/kubernetes --generate --submit --approve --fetch --override --kubeconfig-path $HOME/.kube/config
 ./kube-csr issue e2e --query-svc=kubernetes --generate --submit --approve --fetch --override --kubeconfig-path $HOME/.kube/config
 kubectl get secret -o json | jq -re '.items[].data["ca.crt"]' | base64 -d > ca.crt
 openssl verify -CAfile ca.crt kube-csr.certificate
 
-kubectl apply -f examples/etcd.yaml
 timeout 600 ./.ci/etcd.sh
 
 ./kube-csr garbage-collect --fetched --grace-period=1h --kubeconfig-path $HOME/.kube/config
@@ -19,6 +25,4 @@ timeout 600 ./.ci/etcd.sh
 ./kube-csr garbage-collect --fetched --grace-period=0s --kubeconfig-path $HOME/.kube/config
 ./kube-csr garbage-collect --fetched --denied --expired --grace-period=0s --kubeconfig-path $HOME/.kube/config
 
-echo "testing the lib example:"
-go run examples/issue.go
-echo "lib example returned $?"
+timeout 600 ./.ci/metrics-server.sh

--- a/.ci/etcd.sh
+++ b/.ci/etcd.sh
@@ -2,9 +2,13 @@
 
 while true
 do
-    echo "---"
-    kubectl get statefulset,job,po,csr --all-namespaces -o wide
+    kubectl get statefulset,job,po,csr -n default -o wide
     kubectl get po -n default -o json -l app=etcdctl | jq -re '.items[] | select(.status.phase=="Succeeded")' && exit 0
-    kubectl logs -n default etcd-0 kube-csr
+    for i in {0..2}
+    do
+        echo "===== etcd-${i} kube-csr ====="
+        kubectl logs -n default etcd-${i} kube-csr
+        echo "===== etcd-${i} kube-csr ====="
+    done
     sleep 10
 done

--- a/.ci/metrics-server.sh
+++ b/.ci/metrics-server.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+while true
+do
+    kubectl get deploy,rs,po,csr -n kube-system -o wide
+    kubectl top no && kubectl top po --all-namespaces && exit 0
+    echo "===== metrics-server ====="
+    kubectl logs -n kube-system -l k8s-app=metrics-server
+    echo "===== metrics-server ====="
+    sleep 10
+done

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /example
 /kube-csr.sha512sum
 /.idea
+/.ci/metrics-server.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   matrix:
     - HYPERKUBE_VERSION=1.11.0
     - HYPERKUBE_VERSION=1.10.5
-    - HYPERKUBE_VERSION=1.9.8
+    #- HYPERKUBE_VERSION=1.9.8 TODO restore when pupernetes release 0.7.0
 
 before_install:
   - sudo apt-get update -qq

--- a/examples/metrics-server.yaml
+++ b/examples/metrics-server.yaml
@@ -1,0 +1,189 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+spec:
+  caBundle: "REQUEST_HEADER_CLIENT_CA" # TODO this is for sed: find something better
+  service:
+    name: metrics-server
+    namespace: kube-system
+  group: metrics.k8s.io
+  version: v1beta1
+  groupPriorityMinimum: 100
+  versionPriority: 100
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  template:
+    metadata:
+      name: metrics-server
+      labels:
+        k8s-app: metrics-server
+    spec:
+      initContainers:
+      - name: kube-csr
+        image: quay.io/julienbalestra/kube-csr:master
+        command:
+        - /usr/local/bin/kube-csr
+        - issue
+        - aggregator
+        - --csr-name=$(MY_POD_NAME)-$(MY_POD_UID)
+        - --query-svc=$(MY_POD_NAMESPACE)/metrics-server # get the clusterIP as SAN
+        - --generate
+        - --submit
+        - --approve
+        - --fetch
+        - --subject-alternative-names=$(MY_POD_IP),metrics-server.$(MY_POD_NAMESPACE).svc.cluster.local,metrics-server.$(MY_POD_NAMESPACE).svc
+        - --private-key-file=/etc/certs/metrics-server.private_key
+        - --csr-file=/etc/certs/metrics-server.csr
+        - --certificate-file=/etc/certs/metrics-server.certificate
+        env:
+        - name: MY_POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        volumeMounts:
+        - name: certs
+          mountPath: /etc/certs
+
+      serviceAccountName: metrics-server
+      containers:
+      - name: metrics-server
+        image: gcr.io/google_containers/metrics-server-amd64:v0.2.1
+        imagePullPolicy: Always
+        command:
+        - /metrics-server
+        - --source=kubernetes.summary_api:''?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250
+        - --client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - --tls-cert-file=/etc/certs/metrics-server.certificate
+        - --tls-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - --tls-private-key-file=/etc/certs/metrics-server.private_key
+        - --metric-resolution=6s # caution: value for tests, default is 1m0s
+        volumeMounts:
+        - name: certs
+          mountPath: /etc/certs
+      volumes:
+      - emptyDir:
+        name: certs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    kubernetes.io/name: "Metrics-server"
+spec:
+  selector:
+    k8s-app: metrics-server
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 443
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "certificates.k8s.io"
+  resources:
+  - "certificatesigningrequests"
+  - "certificatesigningrequests/approval"
+  - "certificatesigningrequests/status"
+  verbs:
+  - update
+  - create
+  - get
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---


### PR DESCRIPTION
### What does this PR do?

Example: Add a secure way to configure the metrics-server.

### Additional Notes

I temporally discarded the travis matrix for Kubernetes 1.9 because the API aggregation isn't set in this setup: https://github.com/DataDog/pupernetes/pull/98